### PR TITLE
Add path shadow support for stroke tools

### DIFF
--- a/freehand_tool.py
+++ b/freehand_tool.py
@@ -3,6 +3,7 @@ from PyQt6.QtGui import QPainter, QPen, QPainterPath
 import math
 import time
 from advanced_brush import AdvancedBrush, SimpleBrush
+from shadow_renderer import ShadowRenderer
 
 def ensure_qpointf(point):
     """Point'i QPointF'e dönüştür (dict'ten veya zaten QPointF'ten)"""
@@ -21,7 +22,7 @@ class FreehandTool:
         self.current_color = Qt.GlobalColor.black
         self.current_width = 2
         self.line_style = Qt.PenStyle.SolidLine
-        
+
         # Tablet yazımı için optimize edilmiş ayarlar
         self.min_distance = 1.0  # Mouse için küçük minimum mesafe
         self.tablet_min_distance = 0.3  # Tablet için çok küçük mesafe (real-time)
@@ -32,10 +33,21 @@ class FreehandTool:
         
         # Adaptive smoothing için
         self.velocity_threshold = 20.0  # Hızlı çizimde daha az smoothing
-        
+
         # Brush mode ayarları
         self.brush_mode = 'simple'  # 'simple', 'advanced'
         self.advanced_style = 'solid'  # 'solid', 'dashed', 'dotted', 'zigzag', 'double'
+
+        # Gölge ayarları
+        self.has_shadow = False
+        self.shadow_color = Qt.GlobalColor.black
+        self.shadow_offset_x = 5
+        self.shadow_offset_y = 5
+        self.shadow_blur = 10
+        self.shadow_size = 0
+        self.shadow_opacity = 0.7
+        self.inner_shadow = False
+        self.shadow_quality = "medium"
         
     def start_stroke(self, pos, pressure=1.0, is_tablet=False):
         """Yeni bir serbest çizim başlat"""
@@ -50,7 +62,18 @@ class FreehandTool:
             'style': self.line_style,  # 'style' field'ını kullan
             'brush_mode': self.brush_mode,
             'advanced_style': self.advanced_style,
-            'tablet_mode': is_tablet
+            'tablet_mode': is_tablet,
+            'has_shadow': self.has_shadow,
+            'shadow_color': self.shadow_color,
+            'shadow_offset_x': self.shadow_offset_x,
+            'shadow_offset_y': self.shadow_offset_y,
+            'shadow_blur': self.shadow_blur,
+            'shadow_size': self.shadow_size,
+            'shadow_opacity': self.shadow_opacity,
+            'inner_shadow': self.inner_shadow,
+            'shadow_quality': self.shadow_quality,
+            'cap_style': Qt.PenCapStyle.RoundCap,
+            'join_style': Qt.PenJoinStyle.RoundJoin
         }
         self._last_update_time = time.time()
         
@@ -142,7 +165,13 @@ class FreehandTool:
             
         # QPointF listesine çevir
         qpoint_list = [ensure_qpointf(p) for p in points]
-        
+
+        if len(qpoint_list) >= 2:
+            path = QPainterPath(qpoint_list[0])
+            for qp in qpoint_list[1:]:
+                path.lineTo(qp)
+            ShadowRenderer.draw_shape_shadow(painter, 'path', path, stroke_data)
+
         # Brush mode'a göre çiz
         if brush_mode == 'advanced':
             AdvancedBrush.draw_pen_stroke(painter, qpoint_list, color, width, advanced_style)
@@ -162,9 +191,31 @@ class FreehandTool:
         """Aktif olarak çizilen serbest çizimi çiz (optimized)"""
         if not self.is_drawing or not self.current_stroke or len(self.current_stroke['points']) < 2:
             return
-            
+
         points = self.current_stroke['points']
-        
+
+        qpoint_list = [ensure_qpointf(p) for p in points]
+        if len(qpoint_list) >= 2:
+            preview_data = {
+                'type': 'freehand',
+                'width': self.current_width,
+                'has_shadow': self.has_shadow,
+                'shadow_color': self.shadow_color,
+                'shadow_offset_x': self.shadow_offset_x,
+                'shadow_offset_y': self.shadow_offset_y,
+                'shadow_blur': self.shadow_blur,
+                'shadow_size': self.shadow_size,
+                'shadow_opacity': self.shadow_opacity,
+                'inner_shadow': self.inner_shadow,
+                'shadow_quality': self.shadow_quality,
+                'cap_style': Qt.PenCapStyle.RoundCap,
+                'join_style': Qt.PenJoinStyle.RoundJoin
+            }
+            path = QPainterPath(qpoint_list[0])
+            for qp in qpoint_list[1:]:
+                path.lineTo(qp)
+            ShadowRenderer.draw_shape_shadow(painter, 'path', path, preview_data)
+
         # Aktif çizim için her zaman simple brush kullan (performans)
         tablet_mode = self.current_stroke.get('tablet_mode', False)
         SimpleBrush.draw_simple_stroke(painter, points, self.current_color, self.current_width, tablet_mode, self.line_style)
@@ -186,11 +237,44 @@ class FreehandTool:
         """Advanced brush style ayarla"""
         if style in ['solid', 'dashed', 'dotted', 'dashdot', 'zigzag', 'double']:
             self.advanced_style = style
-            
+
     def get_brush_mode(self):
         """Aktif brush mode'unu döndür"""
         return self.brush_mode
-        
+
     def get_advanced_style(self):
         """Aktif advanced style'ı döndür"""
-        return self.advanced_style 
+        return self.advanced_style
+
+    def set_shadow_enabled(self, enabled):
+        """Gölge durumunu ayarla"""
+        self.has_shadow = enabled
+
+    def set_shadow_color(self, color):
+        """Gölge rengini ayarla"""
+        self.shadow_color = color
+
+    def set_shadow_offset(self, x, y):
+        """Gölge offsetini ayarla"""
+        self.shadow_offset_x = x
+        self.shadow_offset_y = y
+
+    def set_shadow_blur(self, blur):
+        """Gölge bulanıklığını ayarla"""
+        self.shadow_blur = max(0, blur)
+
+    def set_shadow_size(self, size):
+        """Gölge boyutunu ayarla"""
+        self.shadow_size = max(0, size)
+
+    def set_shadow_opacity(self, opacity):
+        """Gölge şeffaflığını ayarla"""
+        self.shadow_opacity = max(0.0, min(1.0, opacity))
+
+    def set_inner_shadow(self, inner):
+        """İç/dış gölge durumunu ayarla"""
+        self.inner_shadow = inner
+
+    def set_shadow_quality(self, quality):
+        """Gölge kalitesini ayarla"""
+        self.shadow_quality = quality

--- a/line_tool.py
+++ b/line_tool.py
@@ -1,7 +1,8 @@
 from PyQt6.QtCore import QPointF
-from PyQt6.QtGui import QPainter, QPen
+from PyQt6.QtGui import QPainter, QPen, QPainterPath
 from PyQt6.QtCore import Qt
 from grid_snap_utils import GridSnapUtils
+from shadow_renderer import ShadowRenderer
 
 class LineTool:
     def __init__(self):
@@ -12,6 +13,17 @@ class LineTool:
         self.line_width = 2
         self.line_style = Qt.PenStyle.SolidLine
         self.background_settings = None  # Snap için arka plan ayarları
+
+        # Gölge ayarları
+        self.has_shadow = False
+        self.shadow_color = Qt.GlobalColor.black
+        self.shadow_offset_x = 5
+        self.shadow_offset_y = 5
+        self.shadow_blur = 10
+        self.shadow_size = 0
+        self.shadow_opacity = 0.7
+        self.inner_shadow = False
+        self.shadow_quality = "medium"
         
     def start_stroke(self, pos, pressure=1.0):
         """Yeni bir çizgi çizimi başlat"""
@@ -47,7 +59,18 @@ class LineTool:
                 'end_point': (self.current_point.x(), self.current_point.y()),
                 'color': self.line_color,
                 'width': self.line_width,
-                'style': self.line_style
+                'style': self.line_style,
+                'has_shadow': self.has_shadow,
+                'shadow_color': self.shadow_color,
+                'shadow_offset_x': self.shadow_offset_x,
+                'shadow_offset_y': self.shadow_offset_y,
+                'shadow_blur': self.shadow_blur,
+                'shadow_size': self.shadow_size,
+                'shadow_opacity': self.shadow_opacity,
+                'inner_shadow': self.inner_shadow,
+                'shadow_quality': self.shadow_quality,
+                'cap_style': Qt.PenCapStyle.RoundCap,
+                'join_style': Qt.PenJoinStyle.RoundJoin
             }
             
             self.cancel_stroke()
@@ -100,6 +123,9 @@ class LineTool:
         pen = QPen(color, width, line_style,
                    Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
         painter.setPen(pen)
+        path = QPainterPath(start_point)
+        path.lineTo(end_point)
+        ShadowRenderer.draw_shape_shadow(painter, 'path', path, stroke_data)
         painter.drawLine(start_point, end_point)
         
     def draw_current_stroke(self, painter):
@@ -113,5 +139,59 @@ class LineTool:
                    Qt.PenCapStyle.RoundCap, Qt.PenJoinStyle.RoundJoin)
         painter.setPen(pen)
         painter.setOpacity(0.7)
+
+        preview_data = {
+            'type': 'line',
+            'width': self.line_width,
+            'has_shadow': self.has_shadow,
+            'shadow_color': self.shadow_color,
+            'shadow_offset_x': self.shadow_offset_x,
+            'shadow_offset_y': self.shadow_offset_y,
+            'shadow_blur': self.shadow_blur,
+            'shadow_size': self.shadow_size,
+            'shadow_opacity': self.shadow_opacity,
+            'inner_shadow': self.inner_shadow,
+            'shadow_quality': self.shadow_quality,
+            'cap_style': Qt.PenCapStyle.RoundCap,
+            'join_style': Qt.PenJoinStyle.RoundJoin
+        }
+
+        path = QPainterPath(self.start_point)
+        path.lineTo(self.current_point)
+        ShadowRenderer.draw_shape_shadow(painter, 'path', path, preview_data)
+
         painter.drawLine(self.start_point, self.current_point)
-        painter.setOpacity(1.0) 
+        painter.setOpacity(1.0)
+
+    def set_shadow_enabled(self, enabled):
+        """Gölge durumunu ayarla"""
+        self.has_shadow = enabled
+
+    def set_shadow_color(self, color):
+        """Gölge rengini ayarla"""
+        self.shadow_color = color
+
+    def set_shadow_offset(self, x, y):
+        """Gölge offsetini ayarla"""
+        self.shadow_offset_x = x
+        self.shadow_offset_y = y
+
+    def set_shadow_blur(self, blur):
+        """Gölge bulanıklığını ayarla"""
+        self.shadow_blur = max(0, blur)
+
+    def set_shadow_size(self, size):
+        """Gölge boyutunu ayarla"""
+        self.shadow_size = max(0, size)
+
+    def set_shadow_opacity(self, opacity):
+        """Gölge şeffaflığını ayarla"""
+        self.shadow_opacity = max(0.0, min(1.0, opacity))
+
+    def set_inner_shadow(self, inner):
+        """İç/dış gölge durumunu ayarla"""
+        self.inner_shadow = inner
+
+    def set_shadow_quality(self, quality):
+        """Gölge kalitesini ayarla"""
+        self.shadow_quality = quality

--- a/main.py
+++ b/main.py
@@ -482,6 +482,16 @@ class MainWindow(QMainWindow):
         self.shape_properties_widget.circleShadowOpacityChanged.connect(self.on_circle_shadow_opacity_changed)
         self.shape_properties_widget.circleShadowInnerChanged.connect(self.on_circle_shadow_inner_changed)
         self.shape_properties_widget.circleShadowQualityChanged.connect(self.on_circle_shadow_quality_changed)
+
+        # Çizgi gölge özellikleri sinyalleri
+        self.shape_properties_widget.strokeShadowEnabledChanged.connect(self.on_stroke_shadow_enabled_changed)
+        self.shape_properties_widget.strokeShadowColorChanged.connect(self.on_stroke_shadow_color_changed)
+        self.shape_properties_widget.strokeShadowOffsetChanged.connect(self.on_stroke_shadow_offset_changed)
+        self.shape_properties_widget.strokeShadowBlurChanged.connect(self.on_stroke_shadow_blur_changed)
+        self.shape_properties_widget.strokeShadowSizeChanged.connect(self.on_stroke_shadow_size_changed)
+        self.shape_properties_widget.strokeShadowOpacityChanged.connect(self.on_stroke_shadow_opacity_changed)
+        self.shape_properties_widget.strokeShadowInnerChanged.connect(self.on_stroke_shadow_inner_changed)
+        self.shape_properties_widget.strokeShadowQualityChanged.connect(self.on_stroke_shadow_quality_changed)
         
         # Grup işlemi sinyalleri
         self.shape_properties_widget.groupShapes.connect(self.on_group_shapes)
@@ -2275,15 +2285,216 @@ class MainWindow(QMainWindow):
             if selected:
                 # Undo için state kaydet
                 current_widget.save_current_state("Change circle shadow quality")
-                
+
                 # Sadece çember stroke'larını güncelle
                 for index in selected:
                     if index < len(current_widget.strokes):
                         stroke = current_widget.strokes[index]
                         if stroke.get('type') == 'circle':
                             stroke['shadow_quality'] = quality
-                
+
                 current_widget.update()
+
+    def on_stroke_shadow_enabled_changed(self, enabled):
+        """Çizgi gölge etkin/pasif değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow enabled")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['has_shadow'] = enabled
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_enabled'):
+                current_widget.line_tool.set_shadow_enabled(enabled)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_enabled'):
+                current_widget.freehand_tool.set_shadow_enabled(enabled)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_enabled'):
+                current_widget.bspline_tool.set_shadow_enabled(enabled)
+
+    def on_stroke_shadow_color_changed(self, color):
+        """Çizgi gölge rengi değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow color")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['shadow_color'] = color
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_color'):
+                current_widget.line_tool.set_shadow_color(color)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_color'):
+                current_widget.freehand_tool.set_shadow_color(color)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_color'):
+                current_widget.bspline_tool.set_shadow_color(color)
+
+    def on_stroke_shadow_offset_changed(self, offset_x, offset_y):
+        """Çizgi gölge offseti değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow offset")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['shadow_offset_x'] = offset_x
+                            stroke['shadow_offset_y'] = offset_y
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_offset'):
+                current_widget.line_tool.set_shadow_offset(offset_x, offset_y)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_offset'):
+                current_widget.freehand_tool.set_shadow_offset(offset_x, offset_y)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_offset'):
+                current_widget.bspline_tool.set_shadow_offset(offset_x, offset_y)
+
+    def on_stroke_shadow_blur_changed(self, blur):
+        """Çizgi gölge bulanıklığı değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow blur")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['shadow_blur'] = blur
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_blur'):
+                current_widget.line_tool.set_shadow_blur(blur)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_blur'):
+                current_widget.freehand_tool.set_shadow_blur(blur)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_blur'):
+                current_widget.bspline_tool.set_shadow_blur(blur)
+
+    def on_stroke_shadow_size_changed(self, size):
+        """Çizgi gölge boyutu değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow size")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['shadow_size'] = size
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_size'):
+                current_widget.line_tool.set_shadow_size(size)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_size'):
+                current_widget.freehand_tool.set_shadow_size(size)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_size'):
+                current_widget.bspline_tool.set_shadow_size(size)
+
+    def on_stroke_shadow_opacity_changed(self, opacity):
+        """Çizgi gölge şeffaflığı değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow opacity")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['shadow_opacity'] = opacity
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_opacity'):
+                current_widget.line_tool.set_shadow_opacity(opacity)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_opacity'):
+                current_widget.freehand_tool.set_shadow_opacity(opacity)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_opacity'):
+                current_widget.bspline_tool.set_shadow_opacity(opacity)
+
+    def on_stroke_shadow_inner_changed(self, inner):
+        """Çizgi iç/dış gölge değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke inner shadow")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['inner_shadow'] = inner
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_inner_shadow'):
+                current_widget.line_tool.set_inner_shadow(inner)
+            if hasattr(current_widget.freehand_tool, 'set_inner_shadow'):
+                current_widget.freehand_tool.set_inner_shadow(inner)
+            if hasattr(current_widget.bspline_tool, 'set_inner_shadow'):
+                current_widget.bspline_tool.set_inner_shadow(inner)
+
+    def on_stroke_shadow_quality_changed(self, quality):
+        """Çizgi gölge kalitesi değişti"""
+        current_widget = self.get_current_drawing_widget()
+        if current_widget and hasattr(current_widget, 'selection_tool'):
+            selected = current_widget.selection_tool.selected_strokes
+            if selected:
+                current_widget.save_current_state("Change stroke shadow quality")
+                for index in selected:
+                    if index < len(current_widget.strokes):
+                        stroke = current_widget.strokes[index]
+                        if hasattr(stroke, 'stroke_type') and stroke.stroke_type == 'image':
+                            continue
+                        if not isinstance(stroke, dict) or 'type' not in stroke:
+                            continue
+                        if stroke['type'] in ['line', 'freehand', 'bspline']:
+                            stroke['shadow_quality'] = quality
+                current_widget.update()
+        if current_widget:
+            if hasattr(current_widget.line_tool, 'set_shadow_quality'):
+                current_widget.line_tool.set_shadow_quality(quality)
+            if hasattr(current_widget.freehand_tool, 'set_shadow_quality'):
+                current_widget.freehand_tool.set_shadow_quality(quality)
+            if hasattr(current_widget.bspline_tool, 'set_shadow_quality'):
+                current_widget.bspline_tool.set_shadow_quality(quality)
 
     def clear_image_cache(self):
         """Image cache klasörünü temizle"""


### PR DESCRIPTION
## Summary
- update the shared shadow renderer to accept generic path data so line-based strokes can render blurred drop shadows
- record and apply stroke shadow properties from the line, freehand, and B-spline tools during drawing and preview
- expose stroke shadow controls in the properties panel and propagate edits through main window handlers

## Testing
- python -m compileall bspline_tool.py freehand_tool.py line_tool.py shadow_renderer.py shape_properties_widget.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd21578cbc83319d05241933a4f4be