### PR TITLE
Remove redundant local import in shape properties widget

### DIFF
--- a/shape_properties_widget.py
+++ b/shape_properties_widget.py
@@ -480,9 +480,8 @@ class ShapePropertiesWidget(QWidget):
         shadow_type_layout = QVBoxLayout()
         shadow_type_layout.setContentsMargins(20, 0, 0, 0)  # Sol taraftan girinti
         
-        from PyQt6.QtWidgets import QRadioButton, QButtonGroup
         self.shadow_type_group = QButtonGroup()
-        
+
         self.outer_shadow_radio = QRadioButton("Dış Gölge")
         self.inner_shadow_radio = QRadioButton("İç Gölge")
         


### PR DESCRIPTION
## Summary
- remove the redundant in-function import of QRadioButton and QButtonGroup in `ShapePropertiesWidget.setup_ui`
- rely on the existing module-level Qt widget imports for shadow radio button controls

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2998cffc8331a3aefa150e7c9479