### PR TITLE
Add PDF background support with importer and session handling

### DIFF
--- a/canvas_renderer.py
+++ b/canvas_renderer.py
@@ -1,5 +1,5 @@
 from PyQt6.QtWidgets import QWidget
-from PyQt6.QtGui import QPainter, QColor, QBrush, QPen
+from PyQt6.QtGui import QPainter, QColor, QBrush, QPen, QImage
 from PyQt6.QtCore import Qt, QRectF, QPointF
 
 class CanvasRenderer:
@@ -198,7 +198,18 @@ class CanvasRenderer:
         # Arka plan rengini ayarla
         bg_color = QColor(self.drawing_widget.background_settings['background_color'])
         painter.fillRect(self.drawing_widget.rect(), QBrush(bg_color))
-        
+
+        if hasattr(self.drawing_widget, 'has_pdf_background') and self.drawing_widget.has_pdf_background():
+            layer = self.drawing_widget.get_pdf_background_layer()
+            if layer:
+                try:
+                    image = layer.get_current_page_image()
+                except Exception:
+                    image = QImage()
+                if not image.isNull():
+                    painter.drawImage(0, 0, image)
+                    return
+
         # Grid/Pattern çizimi
         if self.drawing_widget.background_settings['type'] == 'grid':
             self.draw_grid_background(painter)

--- a/pdf_importer.py
+++ b/pdf_importer.py
@@ -1,0 +1,170 @@
+import hashlib
+import os
+import tempfile
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+from PyQt6.QtGui import QImage
+
+try:  # PyMuPDF is the preferred backend for rasterizing PDF pages
+    import fitz  # type: ignore
+except ImportError:  # pragma: no cover - library might not be available at runtime
+    fitz = None
+
+
+@dataclass
+class PdfBackgroundLayer:
+    """Model object that keeps track of a PDF background source."""
+
+    source_path: str
+    page_count: int
+    dpi: int = 150
+    cache_dir: Optional[str] = None
+    current_page: int = 0
+    _page_cache: Dict[int, QImage] = field(default_factory=dict, init=False, repr=False)
+    _page_paths: Dict[int, str] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.cache_dir is None:
+            base_cache = os.path.join(tempfile.gettempdir(), "dijital_murekkep_pdf_cache")
+            os.makedirs(base_cache, exist_ok=True)
+            identifier = hashlib.md5(self.source_path.encode("utf-8")).hexdigest()
+            self.cache_dir = os.path.join(base_cache, identifier)
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Helper properties
+    # ------------------------------------------------------------------
+    def has_document(self) -> bool:
+        return os.path.exists(self.source_path) and self.page_count > 0
+
+    def get_current_page_size(self):
+        image = self.get_current_page_image()
+        if image.isNull():
+            return None
+        return image.size()
+
+    # ------------------------------------------------------------------
+    # Page navigation helpers
+    # ------------------------------------------------------------------
+    def set_current_page(self, index: int) -> bool:
+        if 0 <= index < self.page_count:
+            if self.current_page != index:
+                self.current_page = index
+            return True
+        return False
+
+    def next_page(self) -> bool:
+        return self.set_current_page(self.current_page + 1)
+
+    def previous_page(self) -> bool:
+        return self.set_current_page(self.current_page - 1)
+
+    # ------------------------------------------------------------------
+    # DPI handling
+    # ------------------------------------------------------------------
+    def set_dpi(self, dpi: int) -> bool:
+        dpi = int(dpi)
+        if dpi <= 0:
+            return False
+        if dpi == self.dpi:
+            return False
+        self.dpi = dpi
+        self.clear_cache()
+        return True
+
+    def clear_cache(self) -> None:
+        for path in list(self._page_paths.values()):
+            try:
+                if os.path.exists(path):
+                    os.remove(path)
+            except OSError:
+                pass
+        self._page_cache.clear()
+        self._page_paths.clear()
+
+    # ------------------------------------------------------------------
+    # Rendering helpers
+    # ------------------------------------------------------------------
+    def get_current_page_image(self) -> QImage:
+        return self.get_page_image(self.current_page)
+
+    def get_page_image(self, index: int) -> QImage:
+        if index in self._page_cache:
+            return self._page_cache[index]
+
+        cached = self._page_paths.get(index)
+        image = QImage()
+        if cached and os.path.exists(cached):
+            image.load(cached)
+            self._page_cache[index] = image
+            return image
+
+        if not fitz:
+            raise RuntimeError("PyMuPDF (fitz) kütüphanesi yüklü değil. PDF sayfaları rasterize edilemiyor.")
+
+        if not self.has_document():
+            return image
+
+        with fitz.open(self.source_path) as document:
+            if index < 0 or index >= document.page_count:
+                return image
+            page = document.load_page(index)
+            scale = self.dpi / 72.0
+            matrix = fitz.Matrix(scale, scale)
+            pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+            image_bytes = pixmap.tobytes("png")
+
+        page_path = os.path.join(self.cache_dir, f"page_{index + 1}_{self.dpi}dpi.png")
+        try:
+            with open(page_path, "wb") as handle:
+                handle.write(image_bytes)
+        except OSError:
+            # Fall back to an in-memory image if writing fails
+            page_path = ""
+
+        if image.loadFromData(image_bytes):
+            self._page_cache[index] = image
+            if page_path:
+                self._page_paths[index] = page_path
+        else:
+            # Image load failed, ensure cache entry removed
+            if page_path and os.path.exists(page_path):
+                try:
+                    os.remove(page_path)
+                except OSError:
+                    pass
+
+        return image
+
+
+class PDFImporter:
+    """Utility responsible for turning PDF pages into QImage instances."""
+
+    def __init__(self, cache_dir: Optional[str] = None):
+        self.cache_dir = cache_dir or os.path.join(tempfile.gettempdir(), "dijital_murekkep_pdf_cache")
+        os.makedirs(self.cache_dir, exist_ok=True)
+
+    def load_pdf(self, file_path: str, dpi: int = 150) -> Optional[PdfBackgroundLayer]:
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(file_path)
+
+        if not fitz:
+            raise RuntimeError("PyMuPDF (fitz) kütüphanesi bulunamadı. Lütfen kurulumu tamamlayın.")
+
+        with fitz.open(file_path) as document:
+            page_count = document.page_count
+
+        if page_count == 0:
+            raise ValueError("Seçilen PDF dosyası boş görünüyor.")
+
+        layer = PdfBackgroundLayer(
+            source_path=file_path,
+            page_count=page_count,
+            dpi=dpi,
+            cache_dir=os.path.join(self.cache_dir, hashlib.md5(file_path.encode("utf-8")).hexdigest())
+        )
+
+        # İlk sayfayı önbelleğe al - kullanıcıya daha hızlı dönüş
+        layer.get_current_page_image()
+        return layer

--- a/session_manager.py
+++ b/session_manager.py
@@ -11,6 +11,10 @@ class SessionManager:
     def __init__(self):
         self.sessions_dir = self.get_sessions_directory()
         self.ensure_sessions_directory()
+        self.pdf_importer = None
+
+    def set_pdf_importer(self, importer):
+        self.pdf_importer = importer
         
     def get_sessions_directory(self):
         """Oturumlar için dizin yolunu al"""
@@ -60,6 +64,11 @@ class SessionManager:
                         'name': tab_name,
                         'background_settings': self.serialize_background_settings(tab_widget.background_settings)
                     }
+
+                    if hasattr(tab_widget, 'export_pdf_background_state'):
+                        pdf_state = tab_widget.export_pdf_background_state()
+                        if pdf_state:
+                            tab_data['pdf_background'] = pdf_state
 
                     if hasattr(tab_widget, 'layer_manager'):
                         tab_data['layers'] = self.serialize_layers(tab_widget)
@@ -181,6 +190,10 @@ class SessionManager:
             if 'background_settings' in tab_data:
                 bg_settings = self.deserialize_background_settings(tab_data['background_settings'])
                 current_widget.set_background_settings(bg_settings)
+
+            if 'pdf_background' in tab_data and hasattr(current_widget, 'import_pdf_background_state'):
+                importer = self.pdf_importer or getattr(main_window, 'pdf_importer', None)
+                current_widget.import_pdf_background_state(tab_data['pdf_background'], importer)
 
             current_widget.update()
 


### PR DESCRIPTION
## Summary
- add a PDF importer module that rasterizes pages to cached QImages
- extend the drawing widget and renderer to manage PDF backgrounds, navigation, and DPI updates
- expose PDF controls in the UI and persist PDF state through the session manager

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd693b3770833196bb282554d20aa7