### PR TITLE
Add PDF background-only rendering for in-place PDF saves

### DIFF
--- a/canvas_renderer.py
+++ b/canvas_renderer.py
@@ -397,10 +397,10 @@ class CanvasRenderer:
             elif stroke_data['type'] == 'circle':
                 self.drawing_widget.circle_tool.draw_stroke(painter, stroke_data)
 
-    def render_with_pdf_background(self, painter):
-        """PDF arka planıyla birlikte export render (zoom/pan olmadan)."""
+    def render_pdf_background_only(self, painter):
+        """Sadece PDF arka planını çiz (stroke'lar olmadan)."""
         painter.setRenderHint(QPainter.RenderHint.Antialiasing)
-        
+
         # Önce PDF arka planını çizmeyi dene
         drew_pdf = False
         if hasattr(self.drawing_widget, 'has_pdf_background') and self.drawing_widget.has_pdf_background():
@@ -413,12 +413,18 @@ class CanvasRenderer:
                 if not image.isNull():
                     painter.drawImage(0, 0, image)
                     drew_pdf = True
-        
+
         # Eğer PDF arka planı yoksa beyaz doldur
         if not drew_pdf:
             bg_color = QColor(Qt.GlobalColor.white)
             painter.fillRect(self.drawing_widget.rect(), QBrush(bg_color))
-        
+
+    def render_with_pdf_background(self, painter):
+        """PDF arka planıyla birlikte export render (zoom/pan olmadan)."""
+        self.render_pdf_background_only(painter)
+
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+
         # Üstüne tüm stroke'ları çiz
         for stroke_data in self.drawing_widget.strokes:
             if hasattr(stroke_data, 'stroke_type') and stroke_data.stroke_type == 'image':

--- a/pdf_exporter.py
+++ b/pdf_exporter.py
@@ -263,8 +263,14 @@ class PDFExporter:
                 painter.translate(x_offset, y_offset)
                 painter.scale(base_scale, base_scale)
 
-                if hasattr(drawing_widget, 'canvas_renderer') and hasattr(drawing_widget.canvas_renderer, 'render_with_pdf_background'):
-                    drawing_widget.canvas_renderer.render_with_pdf_background(painter)
+                if hasattr(drawing_widget, 'canvas_renderer'):
+                    renderer = drawing_widget.canvas_renderer
+                    if hasattr(renderer, 'render_pdf_background_only'):
+                        renderer.render_pdf_background_only(painter)
+                    elif hasattr(renderer, 'render_with_pdf_background'):
+                        renderer.render_with_pdf_background(painter)
+                    else:
+                        drawing_widget.render(painter)
                 else:
                     drawing_widget.render(painter)
 


### PR DESCRIPTION
## Summary
- add a CanvasRenderer helper that renders just the PDF background image and reuse it from the combined renderer
- update the in-place PDF source save to call the background-only renderer while keeping the sharing/export flow rendering annotations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdadc22d648331b7d2cf3e87c72c2a